### PR TITLE
Update functions.lib.php

### DIFF
--- a/htdocs/core/lib/functions.lib.php
+++ b/htdocs/core/lib/functions.lib.php
@@ -2987,6 +2987,9 @@ function dol_print_date($time, $format = '', $tzoutput = 'auto', $outputlangs = 
 		$format = 'daytextshort';
 	}
 
+	// Make sure the format strings are loaded/updated (#20209)
+	$outputlangs->load("main");
+
 	// Do we have to reduce the length of date (year on 2 chars) to save space.
 	// Note: dayinputnoreduce is same than day but no reduction of year length will be done
 	$reduceformat = (!empty($conf->dol_optimize_smallscreen) && in_array($format, array('day', 'dayhour', 'dayhoursec'))) ? 1 : 0;	// Test on original $format param.


### PR DESCRIPTION
Fix #20209

When using multiple languages Dolibarr sometimes switches languages depending on settings. By not loading the "main.lang" file, the proper date formats will not be used and this leads to inconsistency.